### PR TITLE
Complete mallocMC example

### DIFF
--- a/examples/plain-malloc/source/main.cpp
+++ b/examples/plain-malloc/source/main.cpp
@@ -45,7 +45,7 @@ auto makeExecutionDetails() {
   cudaDeviceSetLimit(cudaLimitMallocHeapSize, 1024U * 1024U * 1024U);
 #endif
   uint32_t const numThreadsPerBlock = 256U;
-  uint32_t const numThreads = 4U * numThreadsPerBlock;
+  uint32_t const numThreads = 16U * numThreadsPerBlock;
   auto workdiv = [numThreads, numThreadsPerBlock]() -> alpaka::WorkDivMembers<Dim, Idx> {
     if constexpr (std::is_same_v<alpaka::AccToTag<Acc>, alpaka::TagCpuSerial>) {
       return {{1U}, {1U}, {numThreads}};

--- a/include/kitgenbench/DeviceClock.h
+++ b/include/kitgenbench/DeviceClock.h
@@ -11,6 +11,7 @@
 namespace kitgenbench {
   template <typename TAccTag> struct DeviceClock;
 
+#ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
   template <> struct DeviceClock<alpaka::TagCpuSerial> {
     using DurationType = float;
     ALPAKA_FN_INLINE ALPAKA_FN_ACC static auto clock() {
@@ -25,7 +26,7 @@ namespace kitgenbench {
     }
   };
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#else
 
   template <> struct DeviceClock<alpaka::TagGpuCudaRt> {
     using DurationType = float;


### PR DESCRIPTION
Closes #2 .

Adjust the content of the `simple-mallocMC` example to actually use mallocMC. This is written as a minimal example. Not claiming to be the best way to do this.