### PR TITLE
Fix gersemi settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,4 @@ repos:
     rev: 0.17.0
     hooks:
       - id: gersemi
+        args: [--no-warn-about-unknown-commands]

--- a/examples/simple-mallocMC/CMakeLists.txt
+++ b/examples/simple-mallocMC/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14...3.22)
 
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+    cmake_policy(SET CMP0167 NEW)
 endif()
 project(KitGenBenchExampleSimpleMallocMC LANGUAGES CXX)
 


### PR DESCRIPTION
Hotfix for these kind of annoying `unknown command` warnings. Not a competent enough user of `gersemi` to know how to better handle those (might be an uncompatibility with CPM). Better solutions are welcome.